### PR TITLE
Add RGP staking pool information modal

### DIFF
--- a/app/components/modal/InfoModal.js
+++ b/app/components/modal/InfoModal.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {
+    Modal,
+    ModalOverlay,
+    ModalContent,
+    ModalHeader,
+    ModalFooter,
+    ModalBody,
+    Box,
+    Button,
+    Link,
+    ListItem, OrderedList,
+} from "@chakra-ui/react"
+import { ExternalLinkIcon } from '@chakra-ui/icons'
+
+const InfoModal = ({ onCloseModal, isOpenModal, title, children }) => {
+
+    return (
+        <>
+            <Modal onClose={onCloseModal} isOpen={isOpenModal} isCentered>
+                <ModalOverlay />
+                <ModalContent bg="#120136" color="#fff" borderRadius="20px">
+                    <ModalHeader>{title}</ModalHeader>
+
+                    <ModalBody>
+                        {children}
+                    </ModalBody>
+                    <ModalFooter>
+                        <Button
+                            my="2"
+                            mx="auto"
+                            color="#40BAD5"
+                            width="100%"
+                            background="rgba(64, 186, 213, 0.15)"
+                            cursor="pointer"
+                            border="none"
+                            borderRadius="13px"
+                            padding="10px"
+                            height="50px"
+                            fontSize="16px"
+                            _hover={{ background: 'rgba(64, 186, 213, 0.15)' }}
+                            onClick={onCloseModal}>Close</Button>
+                    </ModalFooter>
+                </ModalContent>
+            </Modal>
+        </>
+    )
+}
+
+export default InfoModal

--- a/app/components/yieldfarm/RGPFarmInfo.js
+++ b/app/components/yieldfarm/RGPFarmInfo.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import {
+    Modal,
+    ModalOverlay,
+    ModalContent,
+    ModalHeader,
+    ModalFooter,
+    ModalBody,
+    Box,
+    Button,
+    Link,
+    ListItem, OrderedList,
+} from "@chakra-ui/react"
+import { ExternalLinkIcon } from '@chakra-ui/icons'
+
+
+const RGPFarmInfo = () => (
+    <>
+        <Box mb={4}>
+            Get a chance to get whitelisted on our special staking pool for the Rigel Protocol selected investors.
+            Selected addresses would enjoy Zero Impermanent Loss on the exclusive Staking Pool and Huge APY!
+        </Box>
+        <Box>
+            To apply:
+        </Box>
+        <OrderedList spacing={4} >
+            <ListItem>
+                Swap or provide liquidity of 1000 RGP or more at our SmartSwap DApp. The higher the amount you swap or lock into the platform the more your chances to be whitelisted!
+            </ListItem>
+            <ListItem>
+                Hold the tokens or keep your liquidity locked for at least 3 weeks on the Rigel Protocol DApp.
+            </ListItem>
+            <ListItem>
+                Submit your details through this {" "}
+                <Link color="#40BAD5" href="https://docs.google.com/forms/d/e/1FAIpQLSdu8uewqjgWdcdBPbM2vI65cVLwHYqFyrkWQHqEfeW_Zltr-w/viewform?usp=sf_link" isExternal>
+                    form <ExternalLinkIcon mx="2px" />
+                </Link>
+            </ListItem>
+        </OrderedList>
+        <Box>All other staking pools are available: (RGP-BUSD, RGP-BNB, BNB-BUSD)</Box>
+    </>
+)
+
+export default RGPFarmInfo;

--- a/app/components/yieldfarm/YieldFarm.js
+++ b/app/components/yieldfarm/YieldFarm.js
@@ -7,7 +7,7 @@ import ETHImage from '../../assets/eth.svg';
 import RGPImage from '../../assets/rgp.svg';
 import BUSDImage from '../../assets/busd.svg';
 
-const YieldFarm = ({ content, wallet, refreshTokenStaked }) => {
+const YieldFarm = ({ content, wallet, onOpenModal, refreshTokenStaked }) => {
   const [showYieldfarm, setShowYieldFarm] = useState(false);
 
   const formatAmount = (value) => {
@@ -100,13 +100,14 @@ const YieldFarm = ({ content, wallet, refreshTokenStaked }) => {
               color="#40BAD5"
               border="0"
               mb="4"
-              cursor="not-allowed"
+
               _hover={{ color: '#423a85' }}
               // onClick={() => setShowYieldFarm(!showYieldfarm)}
-              disabled
+              onClick={onOpenModal}
+
             >
               Unlock
-          </Button>
+            </Button>
           </Tooltip>
           ) :
             (<Button
@@ -129,10 +130,10 @@ const YieldFarm = ({ content, wallet, refreshTokenStaked }) => {
       </Flex>
       {showYieldfarm && (
         <ShowYieldFarmDetails
-         content={content} 
-         wallet={wallet}
-         refreshTokenStaked={refreshTokenStaked}
-         />
+          content={content}
+          wallet={wallet}
+          refreshTokenStaked={refreshTokenStaked}
+        />
       )}
     </>
   );

--- a/app/containers/FarmingPage/index.js
+++ b/app/containers/FarmingPage/index.js
@@ -12,7 +12,9 @@ import Web3 from 'web3';
 import { Box, Flex, Text, useDisclosure } from '@chakra-ui/layout';
 import Layout from 'components/layout';
 import YieldFarm from 'components/yieldfarm/YieldFarm';
+import InfoModal from 'components/modal/InfoModal'
 import FarmingPageModal from 'components/yieldfarm/FarmingPageModal';
+import RGPFarmInfo from 'components/yieldfarm/RGPFarmInfo';
 import {
   masterChefContract,
   rigelToken,
@@ -26,7 +28,7 @@ import {
   smartSwapLPTokenPoolThree,
 } from 'utils/SwapConnect';
 import { tokenList } from '../../utils/constants';
-
+import { useDisclosure as useModalDisclosure } from "@chakra-ui/react";
 import { changeRGPValue } from '../WalletProvider/actions';
 import {
   changeFarmingContent,
@@ -48,6 +50,8 @@ export function FarmingPage(props) {
   const [farmingModal, setFarmingModal] = useState(false);
   const [farmingFee, setFarmingFee] = useState(10);
   const [initialLoad, setInitialLoad] = useState(true)
+  const { isOpen: isOpenModal, onOpen: onOpenModal, onClose: onCloseModal } = useModalDisclosure()
+
 
   useEffect(() => {
     refreshTokenStaked();
@@ -67,16 +71,16 @@ export function FarmingPage(props) {
     };
     RGPfarmingFee();
     checkIfInitialLoading()
-   
+
   }, [wallet]);
   const refreshTokenStaked = () => {
     getYieldFarmingData();
     getFarmTokenBalance();
     getTokenStaked();
-props.changeRGPValue(wallet)
+    props.changeRGPValue(wallet)
   }
-  const checkIfInitialLoading =() =>{
-    initialLoad ? setFarmingModal(true):setFarmingModal(false)
+  const checkIfInitialLoading = () => {
+    initialLoad ? setFarmingModal(true) : setFarmingModal(false)
   }
 
   const getYieldFarmingData = async () => {
@@ -223,7 +227,7 @@ props.changeRGPValue(wallet)
             earned: formatBigNumber(poolThreeEarned),
           },
         ]);
-     setInitialLoad(false)
+        setInitialLoad(false)
       }
     } catch (error) {
       console.error(error);
@@ -514,6 +518,13 @@ props.changeRGPValue(wallet)
   return (
     <div>
       <Layout title="Farming Page">
+        <InfoModal
+          isOpenModal={isOpenModal}
+          onCloseModal={onCloseModal}
+          title="RGP STAKING POOL IS COMING SOON..."
+        >
+          <RGPFarmInfo />
+        </ InfoModal>
         <Flex
           mx={5}
           justifyContent="center"
@@ -552,6 +563,8 @@ props.changeRGPValue(wallet)
               </Flex>
               {props.farming.contents.map(content => (
                 <YieldFarm
+
+                  onOpenModal={onOpenModal}
                   content={content}
                   key={content.id}
                   wallet={wallet}


### PR DESCRIPTION
#### What does this PR do?
- This PR adds the special pool staking information modal to the dapp so that when a user clicks on the unlock button for RGP pool, information on how to get whitelisted is displayed.

#### How can this be tested?
- Navigate to the deployed PR link 
- Click to navigate to the farming page
- Click on the unlock button of the RGP staking pool to view the modal displaying information on how to get whitelisted pending when the RGP farm will be available.

#### Demo? 
- https://www.loom.com/share/0bfacaae49e048bd8f1d3f94107feccb