### PR TITLE
Replace loading icon on farming page on promise rejection

### DIFF
--- a/app/components/yieldfarm/YieldFarm.js
+++ b/app/components/yieldfarm/YieldFarm.js
@@ -7,18 +7,29 @@ import ETHImage from '../../assets/eth.svg';
 import RGPImage from '../../assets/rgp.svg';
 import BUSDImage from '../../assets/busd.svg';
 
-const YieldFarm = ({ content, wallet, onOpenModal, refreshTokenStaked }) => {
+const YieldFarm = ({ content, wallet, onOpenModal, refreshTokenStaked, loadingTotalLiquidity }) => {
   const [showYieldfarm, setShowYieldFarm] = useState(false);
 
   const formatAmount = (value) => {
     return (parseFloat(value)).toLocaleString();
   }
 
+  const totalLiquidityValue = () => {
+    if (loadingTotalLiquidity) {
+      return <Spinner speed="0.65s"
+        color="blue.500" />
+    } else if (content.totalLiquidity) {
+      return `$ ${formatAmount(content.totalLiquidity)}`
+    } else {
+      return '--'
+    }
+  }
+
   return (
     <>
-          <Flex
+      <Flex
         justifyContent="space-between"
-        flexDirection={['column',"column", 'row']}
+        flexDirection={['column', "column", 'row']}
         color="white"
         margin="0 auto"
         background="linear-gradient(
@@ -30,13 +41,13 @@ const YieldFarm = ({ content, wallet, onOpenModal, refreshTokenStaked }) => {
         paddingBottom="4px"
         marginTop="20px"
         borderRadius="10px"
-        width={["95%","95%", "100%"]}
+        width={["95%", "95%", "100%"]}
       >
         <Flex justifyContent="space-between" width="100%">
           <Box
             marginTop="15px"
             align="left"
-            display={['block',"block", 'none']}
+            display={['block', "block", 'none']}
             opacity="0.5"
           >
             Deposit
@@ -49,7 +60,7 @@ const YieldFarm = ({ content, wallet, onOpenModal, refreshTokenStaked }) => {
           <Box
             marginTop="15px"
             align="left"
-            display={['block',"block", 'none']}
+            display={['block', "block", 'none']}
             opacity="0.5"
           >
             Earn
@@ -65,7 +76,7 @@ const YieldFarm = ({ content, wallet, onOpenModal, refreshTokenStaked }) => {
           <Box
             marginTop="15px"
             align="left"
-            display={['block',"block", 'none']}
+            display={['block', "block", 'none']}
             opacity="0.5"
           >
             APY
@@ -74,19 +85,17 @@ const YieldFarm = ({ content, wallet, onOpenModal, refreshTokenStaked }) => {
             {formatAmount(content.ARYValue)} %
           </Box>
         </Flex>
-        <Flex justifyContent="space-between" width="100%" marginBottom={["10px","10px","0"]}>
+        <Flex justifyContent="space-between" width="100%" marginBottom={["10px", "10px", "0"]}>
           <Box
             marginTop="15px"
             align="left"
-            display={['block',"block", 'none']}
+            display={['block', "block", 'none']}
             opacity="0.5"
           >
             Total Liquidity
           </Box>
           <Box marginTop="15px" align="left">
-            {content.totalLiquidity ? `$ ${formatAmount(content.totalLiquidity)}` : <Spinner speed="0.65s"
-
-              color="blue.500" />}
+            {totalLiquidityValue()}
           </Box>
         </Flex>
         <Box align="right" mt={['4', '0']} ml="2">
@@ -128,7 +137,7 @@ const YieldFarm = ({ content, wallet, onOpenModal, refreshTokenStaked }) => {
         </Box>
 
       </Flex>
-   {showYieldfarm && (
+      {showYieldfarm && (
         <ShowYieldFarmDetails
           content={content}
           wallet={wallet}

--- a/app/containers/FarmingPage/actions.js
+++ b/app/containers/FarmingPage/actions.js
@@ -6,7 +6,8 @@
 
 import {
   DEFAULT_ACTION, CHANGE_FARMING_CONTENT, CHANGE_FARMING_CONTENT_TOKEN, CHANGE_RGP_FARMING_FEE,
-  UPDATE_TOTAL_LIQUIDITY, UPDATE_TOKEN_STAKED, UPDATE_FARM_BALANCES, UPDATE_FARM_ALLOWANCE
+  UPDATE_TOTAL_LIQUIDITY, UPDATE_TOKEN_STAKED, UPDATE_FARM_BALANCES, UPDATE_FARM_ALLOWANCE, FARM_DATA_LOADING,
+
 } from './constants';
 
 export function defaultAction() {
@@ -39,6 +40,10 @@ export const updateFarmBalances = value => dispatch => {
 
 export const updateFarmAllowances = value => dispatch => {
   dispatch({ type: UPDATE_FARM_ALLOWANCE, payload: value })
+}
+
+export const farmDataLoading = value => dispatch => {
+  dispatch({ type: FARM_DATA_LOADING, payload: value })
 }
 
 

--- a/app/containers/FarmingPage/constants.js
+++ b/app/containers/FarmingPage/constants.js
@@ -12,3 +12,4 @@ export const UPDATE_TOTAL_LIQUIDITY = 'app/FarmingPage/UPDATE_TOTAL_LIQUIDITY';
 export const UPDATE_TOKEN_STAKED = 'app/FarmingPage/UPDATE_TOKEN_STAKED';
 export const UPDATE_FARM_BALANCES = 'app/FarmingPage/UPDATE_FARM_BALANCES'
 export const UPDATE_FARM_ALLOWANCE = 'app/FarmingPage/UPDATE_FARM_ALLOWANCE'
+export const FARM_DATA_LOADING = 'app/FarmingPage/FARM_DATA_LOADING'

--- a/app/containers/FarmingPage/index.js
+++ b/app/containers/FarmingPage/index.js
@@ -15,6 +15,7 @@ import YieldFarm from 'components/yieldfarm/YieldFarm';
 import InfoModal from 'components/modal/InfoModal'
 import FarmingPageModal from 'components/yieldfarm/FarmingPageModal';
 import RGPFarmInfo from 'components/yieldfarm/RGPFarmInfo';
+import { notify } from 'containers/NoticeProvider/actions';
 
 import {
   masterChefContract,
@@ -38,7 +39,7 @@ import {
   updateTotalLiquidity,
   updateTokenStaked,
   updateFarmBalances,
-
+  farmDataLoading
 } from './actions';
 // import masterChefContract from "../../utils/abis/masterChef.json"
 export function FarmingPage(props) {
@@ -54,6 +55,7 @@ export function FarmingPage(props) {
   const [initialLoad, setInitialLoad] = useState(true)
   const { isOpen: isOpenModal, onOpen: onOpenModal, onClose: onCloseModal } = useModalDisclosure()
   const toast = useToast()
+  const id = "totalLiquidityToast"
 
   useEffect(() => {
     const harvestSubscription = async () => {
@@ -115,6 +117,7 @@ export function FarmingPage(props) {
 
   const getYieldFarmingData = async () => {
     try {
+      props.farmDataLoading(true)
       const masterChef = await masterChefContract();
       const poolLength = await masterChef.poolLength();
       let poolsData = [];
@@ -224,6 +227,19 @@ export function FarmingPage(props) {
       ]);
     } catch (error) {
       console.log(error);
+      if (!toast.isActive(id)) {
+        toast({
+          id,
+          title: "Unable to load data",
+          description: "Ensure your wallet is on BSC network and reload page",
+          status: "error",
+          duration: 9000,
+          isClosable: true,
+          position: "bottom-right",
+        })
+      }
+    } finally {
+      props.farmDataLoading(false)
     }
   };
 
@@ -599,6 +615,7 @@ export function FarmingPage(props) {
                   key={content.id}
                   wallet={wallet}
                   refreshTokenStaked={refreshTokenStaked}
+                  loadingTotalLiquidity={props.farming.loading}
                 />
               ))}
             </Box>
@@ -635,6 +652,8 @@ export default connect(
     updateTotalLiquidity,
     updateTokenStaked,
     updateFarmBalances,
-    changeRGPValue
+    changeRGPValue,
+    farmDataLoading,
+    notify
   },
 )(FarmingPage);

--- a/app/containers/FarmingPage/reducer.js
+++ b/app/containers/FarmingPage/reducer.js
@@ -13,7 +13,8 @@ import {
   UPDATE_TOTAL_LIQUIDITY,
   UPDATE_TOKEN_STAKED,
   UPDATE_FARM_BALANCES,
-  UPDATE_FARM_ALLOWANCE
+  UPDATE_FARM_ALLOWANCE,
+  FARM_DATA_LOADING
 } from './constants';
 
 
@@ -99,6 +100,8 @@ export const initialState = {
       poolAllowance: ''
     },
   ],
+  loading: false,
+  error: null,
 };
 // const user_Individual_Reward = (individualLiquidity / totalLiquidity) * reward
 // Reward = (Multiplier x block diff x reward per block x allocation point ) / Total Allocation Point
@@ -172,6 +175,10 @@ const farmingPageReducer = (state = initialState, action) =>
         allowances.forEach((item, index) => {
           draft.contents[index].poolAllowance = item;
         })
+        break
+
+      case FARM_DATA_LOADING:
+        draft.loading = action.payload;
         break
       default:
         return state;


### PR DESCRIPTION
#### What does this PR do?
- This PR removes the loading icon when there is an error in getting total liquidity data so the the loading icon does not show indefinitely. 
- It also displays an error message when there's an error in loading data.

#### How can this be tested?
- Switch to an unsupported network on the farming page and the loading icon will not show indefinately

#### Demo?
- https://www.loom.com/share/49c171b2fe404331b02c45d7d718f347