### PR TITLE
Prompt a user to switch to BSC mainnet when connected to unsupported networks

### DIFF
--- a/app/components/navbar/ConnectWallet.js
+++ b/app/components/navbar/ConnectWallet.js
@@ -40,6 +40,10 @@ const Wallet = ({ loading, show, connectingWallet, chainId }) => {
   const close = () => {
     modal1Disclosure.onClose();
   };
+  const switchNetwork = () => {
+    onOpen();
+    switchToBSC()
+  }
 
   if (loading) {
     return (
@@ -87,7 +91,7 @@ const Wallet = ({ loading, show, connectingWallet, chainId }) => {
           _hover={{ background: 'rgba(64, 186, 213,0.35)' }}
           _active={{ outline: '#29235E' }}
           _expanded={{ bg: '#29235E' }}
-          onClick={switchToBSC}
+          onClick={switchNetwork}
         >
           Unsupported Network
         </Button>

--- a/app/components/navbar/ConnectWallet.js
+++ b/app/components/navbar/ConnectWallet.js
@@ -20,7 +20,7 @@ import { ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icons';
 import { connect } from 'react-redux';
 import { connectingWallet } from 'containers/WalletProvider/actions';
 import styles from '../../styles/navbar.css';
-import { isSupportedNetwork } from '../../utils/wallet-wiget/connection'
+import { isSupportedNetwork, switchToBSC } from '../../utils/wallet-wiget/connection'
 
 import Options from './Options';
 import Loading from './Loading';
@@ -87,7 +87,7 @@ const Wallet = ({ loading, show, connectingWallet, chainId }) => {
           _hover={{ background: 'rgba(64, 186, 213,0.35)' }}
           _active={{ outline: '#29235E' }}
           _expanded={{ bg: '#29235E' }}
-          onClick={onOpen}
+          onClick={switchToBSC}
         >
           Unsupported Network
         </Button>

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -25,7 +25,7 @@ import Toast from '../../components/Toast';
 import { reConnect, disconnectWallet, updateChainId } from '../WalletProvider/actions';
 import TrustWallet from './../../components/TrustWallet/index';
 import { setWallet } from 'containers/WalletProvider/saga';
-import { isSupportedNetwork } from './../../utils/wallet-wiget/connection'
+import { isSupportedNetwork, switchToBSC } from './../../utils/wallet-wiget/connection'
 import { notify } from 'containers/NoticeProvider/actions';
 
 
@@ -77,6 +77,8 @@ const App = props => {
     if (isSupportedNetwork(chainID)) {
       listener(wallet, props);
       reConnector(props);
+    } else {
+      switchToBSC();
     }
   }
 

--- a/app/utils/wallet-wiget/connection.js
+++ b/app/utils/wallet-wiget/connection.js
@@ -5,6 +5,7 @@ import configureStore from 'configureStore';
 import { WALLET_CONNECTED } from 'containers/WalletProvider/constants';
 import { formatBalance } from 'utils/UtilFunc';
 import { balanceAbi } from '../constants';
+import { add } from 'lodash';
 const store = configureStore();
 
 export const provider = async () => {
@@ -128,4 +129,50 @@ const supportedNetworks = ["0x61", '0x38', 'chainId']
 
 export const isSupportedNetwork = (chainId) => {
   return supportedNetworks.includes(chainId);
+}
+
+
+const checkMetamask = async () => {
+  const provider = await detectEthereumProvider();
+  return !!provider;
+}
+
+export const switchToBSC = async () => {
+  if (checkMetamask()) {
+    try {
+      await ethereum.request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: '0x38' }],
+      });
+    } catch (switchError) {
+      // This error code indicates that the chain has not been added to MetaMask.
+      if (switError.code === 4902) {
+        addBSCToMetamask()
+      }
+      // handle other  errors codes
+    }
+  }
+}
+
+const addBSCToMetamask = async () => {
+  try {
+    await ethereum.request({
+      method: 'wallet_addEthereumChain',
+      params: [
+        {
+          chainId: '0x38',
+          chainName: 'Smart Chain',
+          nativeCurrency: {
+            name: 'BSC Mainet',
+            symbol: 'BNB',
+            decimals: 18,
+          },
+          rpcUrls: ['https://bsc-dataseed.binance.org/'],
+          blockExplorerUrls: ['https://bscscan.com/'],
+        },
+      ],
+    });
+  } catch (addError) {
+    console.log(addError)
+  }
 }


### PR DESCRIPTION
#### What does this PR do?
- This PR prompts a user to switch to BSC mainnet when a user is connected to an unsupported network
- it also helps loads the BSC mainnet configuration for metamask that dont have BSC mainnet setup
- Clicking the unsupported network also opens up metamask for the user to switch to bsc mainnet

#### Demo?
- https://www.loom.com/share/148a209f5ddb4aba89140d6da5dccc18