### PR TITLE
Add special pool mainnet address

### DIFF
--- a/app/components/yieldfarm/RGPFarmInfo.js
+++ b/app/components/yieldfarm/RGPFarmInfo.js
@@ -31,8 +31,8 @@ const RGPFarmInfo = () => (
                 </Link>
             </ListItem>
         </OrderedList>
-       
-        <Box>All other staking pools are available: (RGP-BUSD, RGP-BNB, BNB-BUSD)</Box>
+
+        <Box>Other staking pools do not require address whitelist</Box>
     </>
 )
 

--- a/app/components/yieldfarm/YieldFarm.js
+++ b/app/components/yieldfarm/YieldFarm.js
@@ -7,12 +7,12 @@ import ETHImage from '../../assets/eth.svg';
 import RGPImage from '../../assets/rgp.svg';
 import BUSDImage from '../../assets/busd.svg';
 
-const YieldFarm = ({ 
-  content, 
-  wallet, 
+const YieldFarm = ({
+  content,
+  wallet,
   onOpenModal,
-  setShowModalWithInput, 
-  refreshTokenStaked, 
+  setShowModalWithInput,
+  refreshTokenStaked,
   loadingTotalLiquidity,
   isAddressWhitelist
 }) => {
@@ -32,11 +32,10 @@ const YieldFarm = ({
       return '--'
     }
   }
-  const checkIfAddressIsWhiteListed = () =>{
-    if(isAddressWhitelist){
+  const checkIfAddressIsWhiteListed = () => {
+    if (isAddressWhitelist) {
       setShowYieldFarm(!showYieldfarm)
-    }else{
-      // setShowModalWithInput(true)
+    } else {
       onOpenModal()
     }
   }
@@ -114,7 +113,7 @@ const YieldFarm = ({
           </Box>
         </Flex>
         <Box align="right" mt={['4', '0']} ml="2">
-          {content.id == 1 ? (<Tooltip label="Coming soon" >
+          {content.id == 1 ? (
 
             <Button
               w={['100%', '100%', '146px']}
@@ -124,15 +123,12 @@ const YieldFarm = ({
               color="#40BAD5"
               border="0"
               mb="4"
-
               _hover={{ color: '#423a85' }}
-              onClick={() => wallet.chainId == "0x61" ? checkIfAddressIsWhiteListed() : onOpenModal()}
-            // onClick={onOpenModal}
-
+              onClick={checkIfAddressIsWhiteListed}
             >
               Unlock
             </Button>
-          </Tooltip>
+
           ) :
             (<Button
               w={['100%', '100%', '146px']}

--- a/app/containers/FarmingPage/index.js
+++ b/app/containers/FarmingPage/index.js
@@ -87,10 +87,10 @@ export function FarmingPage(props) {
 
 
   useEffect(() => {
-    if(wallet.chainId == "0x61"){
+    if (wallet.chainId == "0x61") {
       checkIfUserAddressHasBeenWhiteListed()
     }
-    
+
     refreshTokenStaked();
   }, [wallet]);
 
@@ -120,18 +120,18 @@ export function FarmingPage(props) {
     initialLoad ? setFarmingModal(true) : setFarmingModal(false)
   }
 
-  const checkIfUserAddressHasBeenWhiteListed =async ()=>{
-    try{
+  const checkIfUserAddressHasBeenWhiteListed = async () => {
+    try {
       const specialPool = await RGPSpecialPool();
-      const isItWhiteListed =await specialPool.isWhitelist(wallet.address)
+      const isItWhiteListed = await specialPool.isWhitelist(wallet.address)
       setIsAddressWhitelist(isItWhiteListed)
-    }catch(e){
+    } catch (e) {
       console.error(e)
     }
-    
+
   }
-  const submitDataToGetWhitelisted = () =>{
-    console.log({dataInputToGetWhiteListed})
+  const submitDataToGetWhitelisted = () => {
+    console.log({ dataInputToGetWhiteListed })
     onCloseModal()
     toast({
       title: "Address successfully submitted",
@@ -647,7 +647,7 @@ export function FarmingPage(props) {
           // submitData={submitDataToGetWhitelisted}
           // InputData={dataInputToGetWhiteListed}
           // setInputData={setDataInputToGetWhiteListed}
-          title="RGP STAKING POOL IS COMING SOON..."
+          title="YOUR ADDRESS IS NOT WHITELISTED FOR RGP STAKING"
         >
           <RGPFarmInfo />
         </ InfoModal>
@@ -689,7 +689,7 @@ export function FarmingPage(props) {
               </Flex>
               {props.farming.contents.map(content => (
                 <YieldFarm
-                  isAddressWhitelist = {isAddressWhitelist}
+                  isAddressWhitelist={isAddressWhitelist}
                   onOpenModal={onOpenModal}
                   setShowModalWithInput={setShowModalWithInput}
                   content={content}

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -55,7 +55,7 @@ const BSCMainnet = {
   SmartFactory: '0x655333A1cD74232C404049AF9d2d6cF1244E71F6',
   SMART_SWAPPING: '0xf78234E21f1F34c4D8f65faF1BC82bfc0fa24920',
   ETHRGPSMARTSWAPPAIR: '0x9218BFB996A9385C3b9633f87e9D68304Ef5a1e5',
-  specialPool: '',
+  specialPool: '0x100514759DCD6e2Ccbb9EB87481b96de28C4b77F',
   SmartSwap_LP_Token: '0x7f91f8B8Dac13DAc386058C12113936987F6Be9d',
   RigelSmartContract: '0xFA262F303Aa244f9CC66f312F0755d89C3793192',
   masterChef: '0x7d59AAD43Cef13Cd077308D37C3A39D3b4B6C924',
@@ -71,7 +71,7 @@ const BSCTestnet = {
   SmartFactory: '0x7B14Ab51fAF91926a2214c91Ce9CDaB5C0E1A1c3',
   SMART_SWAPPING: '0x00749e00Af4359Df5e8C156aF6dfbDf30dD53F44',
   ETHRGPSMARTSWAPPAIR: '0xca01606438556b299005b36B86B38Fe506eadF9F',
-  specialPool: '0x4Be275eF94AF45E163c6b3182467191025E883B4',
+  specialPool: '0x7fE2Ec631716FeF3657BcB8d80CffBB2A34F7617',
   RigelSmartContract: '0x9f0227A21987c1fFab1785BA3eBa60578eC1501B',
   masterChef: '0x71C07230dF8b60aef6e3821CA2Dee530966EFc2D',
   masterChefPoolOne: '0x0B0a1E07931bD7991a104218eE15BAA682c05e01',
@@ -86,12 +86,12 @@ export const SMART_SWAP =
   checkNetVersion() === BSC_MAIN_NET_ID.toString() ? BSCMainnet : BSCTestnet;
 
 export const tokenList = [
-  { name: 'Select a token', symbol: 'SELECT A TOKEN', img: '',available:true },
+  { name: 'Select a token', symbol: 'SELECT A TOKEN', img: '', available: true },
   {
     symbol: 'RGP',
     abi: RigelToken,
-    available:true,
-    imported:false,
+    available: true,
+    imported: false,
     name: 'Rigel Protocol',
     img: '../../assets/rgp.svg',
     address:
@@ -102,8 +102,8 @@ export const tokenList = [
   {
     abi: BUSD,
     symbol: 'BUSD',
-    available:true,
-    imported:false,
+    available: true,
+    imported: false,
     name: 'Binance USD',
     img: '../../assets/bnb.svg',
     address:
@@ -122,8 +122,8 @@ export const tokenList = [
   {
     abi: WETH9,
     symbol: 'WBNB',
-    available:true,
-    imported:false,
+    available: true,
+    imported: false,
     name: 'Wrapped BNB',
     img: '../../assets/eth.svg',
     address:
@@ -134,8 +134,8 @@ export const tokenList = [
   {
     abi: WETH9,
     symbol: 'BNB',
-    available:true,
-    imported:false,
+    available: true,
+    imported: false,
     name: 'BNB',
 
     img: '../../assets/eth.svg',


### PR DESCRIPTION
#### What does this PR do?
- This PR adds special pool mainnet address to allow the special pool features work on the mainnet

#### What has been completed?
- Add special pool address for mainnet
- Removed `coming soon` tooltip

#### How can this be tested?
- click on the deployed PR link below and switch to BSC mainnet
- Navigate to the farming section of the DApp
- Ensure your address has been whitelisted and click on the unlock button
- Use the special pool features if your address is whitelisted

#### Demo?
- https://www.loom.com/share/37d9eabef1b942bea5de11e86f477c45