### PR TITLE
Fix approve token for swap

### DIFF
--- a/app/components/sendToken/index.js
+++ b/app/components/sendToken/index.js
@@ -687,6 +687,7 @@ export const Manual = props => {
   };
 
   const triggerAccountCheck = async () => {
+    const approveAmount = 1000000000000000;
     if (checkForAllVariables()) {
       if (userHasApproveToken) {
         return openModal1();
@@ -697,7 +698,7 @@ export const Manual = props => {
         wallet.address,
         selectedToken.address,
         wallet.signer,
-        selectedToken.balance,
+        approveAmount,
       );
       const { confirmations, status } = await sendTransaction.wait(3);
       if (
@@ -751,7 +752,7 @@ export const Manual = props => {
         setTimeout(() => openModal3(), 1000);
         const { hash } = sendTransaction
         setURLNetwork("")
-        setTimeout(()=> setURLNetwork(createURLNetwork(hash)) ,3000)
+        setTimeout(() => setURLNetwork(createURLNetwork(hash)), 3000)
         const { confirmations, status } = await sendTransaction.wait(3);
         if (
           typeof sendTransaction.hash != 'undefined' &&


### PR DESCRIPTION
#### What does this PR do?
- This PR fixes the bug on approve token swap. When a user clicks on the approve token button, the Metamask extension does not pop up for the user to confirm the transaction. This PR fixes it and the token is approved.

#### What has been completed?
- Approve token before swap

#### How can this be tested?
- Connect to a metamask address that has not approved RGP and try to swap RGP for another token.

#### Demo?
- https://www.loom.com/share/b51167b174d044ffa24adccb1cb4d0c2