### PR TITLE
Display information modal on get address whitelisted for RGP staking

### DIFF
--- a/app/components/stakingFarm/StakingFarm.js
+++ b/app/components/stakingFarm/StakingFarm.js
@@ -105,7 +105,7 @@ const YieldFarm = ({
           </Box>
         </Flex>
         <Box align="right" mt={['4', '0']} ml="2">
-          {content.id === 1 ? (
+          {content.id === '1' ? (
             <Button
               w={['100%', '100%', '146px']}
               h="40px"

--- a/app/containers/FarmingPage/index.js
+++ b/app/containers/FarmingPage/index.js
@@ -131,7 +131,7 @@ export function FarmingPage(props) {
       const specialPool = await RGPSpecialPool();
       const totalStaking = await specialPool.totalStaking();
       return totalStaking;
-    } catch (error) {}
+    } catch (error) { }
   };
   useEffect(() => {
     getFarmData();
@@ -587,7 +587,7 @@ export function FarmingPage(props) {
         });
       }
       setLiquidities([...pairs]);
-    } catch (error) {}
+    } catch (error) { }
   };
   const changeVersion = () => {
     history.push('/farming-v2');
@@ -608,7 +608,7 @@ export function FarmingPage(props) {
         >
           <RGPFarmInfo />
         </InfoModal>
-        <FarmingV2Alert message="This is the V1 Farm." />
+        <FarmingV2Alert message="This is the V1 Farm. Please move your LP deposits to the V2 farm" />
 
         <Flex justifyContent="flex-end">
           <Tabs

--- a/app/containers/V2FarmingPage/index.js
+++ b/app/containers/V2FarmingPage/index.js
@@ -64,7 +64,7 @@ export function FarmingV2Page(props) {
   const history = useHistory();
 
   const { wallet } = props.wallet;
-  const [isAddressWhitelist, setIsAddressWhitelist] = useState(false);
+  const [isAddressWhitelist, setIsAddressWhitelist] = useState(true);
   const [dataInputToGetWhiteListed] = useState('');
   const [farmingModal, setFarmingModal] = useState(false);
   const [farmingFee, setFarmingFee] = useState(10);
@@ -158,7 +158,7 @@ export function FarmingV2Page(props) {
       const specialPool = await RGPSpecialPool();
       const totalStaking = await specialPool.totalStaking();
       return totalStaking;
-    } catch (error) {}
+    } catch (error) { }
   };
   useEffect(() => {
     getFarmData();
@@ -724,7 +724,7 @@ export function FarmingV2Page(props) {
         });
       }
       setLiquidities([...pairs]);
-    } catch (error) {}
+    } catch (error) { }
   };
 
   const changeVersion = () => {


### PR DESCRIPTION
#### What does this PR do?
- This PR fixes the modal display to show users information on how to get whitelisted to stake on RGP special pool farm

#### What has been completed?
- [x] Fix the comparison operation that is not allowing the modal to popup.

#### How should the changes be manually tested?
- Connect to the Dapp with an address that has not been whitelisted on the special pool farm
- Navigate to the v2 farming page
- Click on the staking tab
- Click on the unlock button of the RGP staking farm
- A modal showing information on how to get whitelisted pops up

#### Any Background context or information you want to provide?
- Users need to get their addresses whitelisted by the admin before they can stake on the RGP special pool farm.
- Other LP farms do not require address whitelisting.

#### Demo Video and screenshots?
- https://www.loom.com/share/c2150381bb6b49e6bd39256add149106